### PR TITLE
Release main/Smdn.LibHighlightSharp.Bindings-3.60.0

### DIFF
--- a/doc/api-list/Smdn.LibHighlightSharp.Bindings/Smdn.LibHighlightSharp.Bindings-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.LibHighlightSharp.Bindings/Smdn.LibHighlightSharp.Bindings-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.LibHighlightSharp.Bindings.dll (Smdn.LibHighlightSharp.Bindings-3.56.0)
+// Smdn.LibHighlightSharp.Bindings.dll (Smdn.LibHighlightSharp.Bindings-3.60.0)
 //   Name: Smdn.LibHighlightSharp.Bindings
-//   AssemblyVersion: 3.56.0.0
-//   InformationalVersion: 3.56.0+090fddc06d3ce81c1dbd0cf3254604dee9c77535
+//   AssemblyVersion: 3.60.0.0
+//   InformationalVersion: 3.60.0+11c9c1634ccf3d96d71724a669c7875d8244f937
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 
@@ -117,6 +117,7 @@ namespace Smdn.LibHighlightSharp.Bindings {
     public SWIGTYPE_p_std__vectorT_std__string_t getPosTestErrors() {}
     public bool getPrintLineNumbers() {}
     public bool getPrintZeroes() {}
+    public virtual string getStyleDefinition() {}
     public string getStyleInputPath() {}
     public string getStyleName() {}
     public string getStyleOutputPath() {}
@@ -127,6 +128,7 @@ namespace Smdn.LibHighlightSharp.Bindings {
     public SyntaxReader getSyntaxReader() {}
     public string getSyntaxRegexError() {}
     public string getThemeCatDescription() {}
+    public float getThemeContrast() {}
     public string getThemeDescription() {}
     public string getThemeInitError() {}
     public string getTitle() {}
@@ -139,6 +141,7 @@ namespace Smdn.LibHighlightSharp.Bindings {
     public bool printExternalStyle(string outFile) {}
     public virtual bool printIndexFile(SWIGTYPE_p_std__vectorT_std__string_t fileList, string outPath) {}
     public bool printPersistentState(string outFile) {}
+    public string readUserStyleDef() {}
     public bool requiresTwoPassParsing() {}
     public void resetSyntaxReaders() {}
     public void setBaseFont(string fontName) {}
@@ -368,6 +371,7 @@ namespace Smdn.LibHighlightSharp.Bindings {
     public LoadResult load(string langDefPath, string pluginReadFilePath, OutputType outputType) {}
     public bool matchesOpenDelimiter(string token, State s, int openDelimId) {}
     public bool needsReload(string langDefPath) {}
+    public bool requiresParamUpdate() {}
     public bool requiresTwoPassRun() {}
     public void restoreLangEndDelim(string langPath) {}
     public void setInputFileName(string fn) {}

--- a/doc/api-list/Smdn.LibHighlightSharp.Bindings/Smdn.LibHighlightSharp.Bindings-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.LibHighlightSharp.Bindings/Smdn.LibHighlightSharp.Bindings-netstandard2.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.LibHighlightSharp.Bindings.dll (Smdn.LibHighlightSharp.Bindings-3.56.0)
+// Smdn.LibHighlightSharp.Bindings.dll (Smdn.LibHighlightSharp.Bindings-3.60.0)
 //   Name: Smdn.LibHighlightSharp.Bindings
-//   AssemblyVersion: 3.56.0.0
-//   InformationalVersion: 3.56.0+090fddc06d3ce81c1dbd0cf3254604dee9c77535
+//   AssemblyVersion: 3.60.0.0
+//   InformationalVersion: 3.60.0+11c9c1634ccf3d96d71724a669c7875d8244f937
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 
@@ -117,6 +117,7 @@ namespace Smdn.LibHighlightSharp.Bindings {
     public SWIGTYPE_p_std__vectorT_std__string_t getPosTestErrors() {}
     public bool getPrintLineNumbers() {}
     public bool getPrintZeroes() {}
+    public virtual string getStyleDefinition() {}
     public string getStyleInputPath() {}
     public string getStyleName() {}
     public string getStyleOutputPath() {}
@@ -127,6 +128,7 @@ namespace Smdn.LibHighlightSharp.Bindings {
     public SyntaxReader getSyntaxReader() {}
     public string getSyntaxRegexError() {}
     public string getThemeCatDescription() {}
+    public float getThemeContrast() {}
     public string getThemeDescription() {}
     public string getThemeInitError() {}
     public string getTitle() {}
@@ -139,6 +141,7 @@ namespace Smdn.LibHighlightSharp.Bindings {
     public bool printExternalStyle(string outFile) {}
     public virtual bool printIndexFile(SWIGTYPE_p_std__vectorT_std__string_t fileList, string outPath) {}
     public bool printPersistentState(string outFile) {}
+    public string readUserStyleDef() {}
     public bool requiresTwoPassParsing() {}
     public void resetSyntaxReaders() {}
     public void setBaseFont(string fontName) {}
@@ -368,6 +371,7 @@ namespace Smdn.LibHighlightSharp.Bindings {
     public LoadResult load(string langDefPath, string pluginReadFilePath, OutputType outputType) {}
     public bool matchesOpenDelimiter(string token, State s, int openDelimId) {}
     public bool needsReload(string langDefPath) {}
+    public bool requiresParamUpdate() {}
     public bool requiresTwoPassRun() {}
     public void restoreLangEndDelim(string langPath) {}
     public void setInputFileName(string fn) {}

--- a/doc/api-list/Smdn.LibHighlightSharp.Bindings/Smdn.LibHighlightSharp.Bindings-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.LibHighlightSharp.Bindings/Smdn.LibHighlightSharp.Bindings-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.LibHighlightSharp.Bindings.dll (Smdn.LibHighlightSharp.Bindings-3.56.0)
+// Smdn.LibHighlightSharp.Bindings.dll (Smdn.LibHighlightSharp.Bindings-3.60.0)
 //   Name: Smdn.LibHighlightSharp.Bindings
-//   AssemblyVersion: 3.56.0.0
-//   InformationalVersion: 3.56.0+090fddc06d3ce81c1dbd0cf3254604dee9c77535
+//   AssemblyVersion: 3.60.0.0
+//   InformationalVersion: 3.60.0+11c9c1634ccf3d96d71724a669c7875d8244f937
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 
@@ -117,6 +117,7 @@ namespace Smdn.LibHighlightSharp.Bindings {
     public SWIGTYPE_p_std__vectorT_std__string_t getPosTestErrors() {}
     public bool getPrintLineNumbers() {}
     public bool getPrintZeroes() {}
+    public virtual string getStyleDefinition() {}
     public string getStyleInputPath() {}
     public string getStyleName() {}
     public string getStyleOutputPath() {}
@@ -127,6 +128,7 @@ namespace Smdn.LibHighlightSharp.Bindings {
     public SyntaxReader getSyntaxReader() {}
     public string getSyntaxRegexError() {}
     public string getThemeCatDescription() {}
+    public float getThemeContrast() {}
     public string getThemeDescription() {}
     public string getThemeInitError() {}
     public string getTitle() {}
@@ -139,6 +141,7 @@ namespace Smdn.LibHighlightSharp.Bindings {
     public bool printExternalStyle(string outFile) {}
     public virtual bool printIndexFile(SWIGTYPE_p_std__vectorT_std__string_t fileList, string outPath) {}
     public bool printPersistentState(string outFile) {}
+    public string readUserStyleDef() {}
     public bool requiresTwoPassParsing() {}
     public void resetSyntaxReaders() {}
     public void setBaseFont(string fontName) {}
@@ -368,6 +371,7 @@ namespace Smdn.LibHighlightSharp.Bindings {
     public LoadResult load(string langDefPath, string pluginReadFilePath, OutputType outputType) {}
     public bool matchesOpenDelimiter(string token, State s, int openDelimId) {}
     public bool needsReload(string langDefPath) {}
+    public bool requiresParamUpdate() {}
     public bool requiresTwoPassRun() {}
     public void restoreLangEndDelim(string langPath) {}
     public void setInputFileName(string fn) {}


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #45](https://github.com/smdn/Smdn.LibHighlightSharp/actions/runs/3613511855).

# Release target
- package_target_tag: `new-release/main/Smdn.LibHighlightSharp.Bindings-3.60.0`
- package_prevver_ref: `releases/Smdn.LibHighlightSharp.Bindings-3.56.0`
- package_prevver_tag: `releases/Smdn.LibHighlightSharp.Bindings-3.56.0`
- package_id: `Smdn.LibHighlightSharp.Bindings`
- package_id_with_version: `Smdn.LibHighlightSharp.Bindings-3.60.0`
- package_version: `3.60.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.LibHighlightSharp.Bindings-3.60.0-1670161026`
- release_tag: `releases/Smdn.LibHighlightSharp.Bindings-3.60.0`
- release_draft: `false` ❗Change this value to `true` to create release note as draft.
- release_note_url: [`https://gist.github.com/9a6e92e5eb7ca6e652c493a33cf355a1`](https://gist.github.com/9a6e92e5eb7ca6e652c493a33cf355a1)
- artifact_name_nupkg: `Smdn.LibHighlightSharp.Bindings.3.60.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec
```nuspec
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Smdn.LibHighlightSharp.Bindings</id>
    <version>3.60.0</version>
    <title>Smdn.LibHighlightSharp.Bindings</title>
    <authors>smdn</authors>
    <license type="expression">GPL-3.0-or-later</license>
    <licenseUrl>https://licenses.nuget.org/GPL-3.0-or-later</licenseUrl>
    <icon>Smdn.LibHighlightSharp.Bindings.png</icon>
    <readme>README.md</readme>
    <projectUrl>https://smdn.jp/works/libs/Smdn.LibHighlightSharp/</projectUrl>
    <description>Provides `libhighlight`, the [Highlight v3.60](http://andre-simon.de/doku/highlight/en/highlight.php) native library for various platforms, and the managed bindings for it.</description>
    <copyright>Copyright © 2022 smdn</copyright>
    <tags>smdn.jp highlighting highlighter syntax-highlighting SyntaxHighlighting native bindings libhighlight</tags>
    <repository type="git" url="https://github.com/smdn/Smdn.LibHighlightSharp" branch="main" commit="11c9c1634ccf3d96d71724a669c7875d8244f937" />
    <dependencies>
      <group targetFramework="net6.0" />
      <group targetFramework=".NETStandard2.0" />
      <group targetFramework=".NETStandard2.1" />
    </dependencies>
  </metadata>
  <files>
    <file src="/home/runner/work/Smdn.LibHighlightSharp/Smdn.LibHighlightSharp/src/Smdn.LibHighlightSharp.Bindings/bin/Release/net6.0/Smdn.LibHighlightSharp.Bindings.dll" target="lib/net6.0/Smdn.LibHighlightSharp.Bindings.dll" />
    <file src="/home/runner/work/Smdn.LibHighlightSharp/Smdn.LibHighlightSharp/src/Smdn.LibHighlightSharp.Bindings/bin/Release/netstandard2.0/Smdn.LibHighlightSharp.Bindings.dll" target="lib/netstandard2.0/Smdn.LibHighlightSharp.Bindings.dll" />
    <file src="/home/runner/work/Smdn.LibHighlightSharp/Smdn.LibHighlightSharp/src/Smdn.LibHighlightSharp.Bindings/bin/Release/netstandard2.1/Smdn.LibHighlightSharp.Bindings.dll" target="lib/netstandard2.1/Smdn.LibHighlightSharp.Bindings.dll" />
    <file src="/home/runner/work/Smdn.LibHighlightSharp/Smdn.LibHighlightSharp/.nuget/packages/smdn.msbuild.projectassets.common/1.1.3/project/images/package-icon.png" target="Smdn.LibHighlightSharp.Bindings.png" />
    <file src="/home/runner/work/Smdn.LibHighlightSharp/Smdn.LibHighlightSharp/COPYING.txt" target="COPYING.txt" />
    <file src="/home/runner/work/Smdn.LibHighlightSharp/Smdn.LibHighlightSharp/src/Smdn.LibHighlightSharp.Bindings/libhighlight/highlight-v3_60_0_0.SHA1SUMS.txt" target="libhighlight/SHA1SUMS.txt" />
    <file src="/home/runner/work/Smdn.LibHighlightSharp/Smdn.LibHighlightSharp/src/Smdn.LibHighlightSharp.Bindings/bin/Release/NOTICE.md" target="NOTICE.md" />
    <file src="/home/runner/work/Smdn.LibHighlightSharp/Smdn.LibHighlightSharp/src/Smdn.LibHighlightSharp.Bindings/bin/Release/README.md" target="README.md" />
    <file src="/home/runner/work/Smdn.LibHighlightSharp/Smdn.LibHighlightSharp/src/Smdn.LibHighlightSharp.Bindings/runtimes/ubuntu.22.04-x64/native/libhighlight-v3_60_0_0.so" target="runtimes/ubuntu.22.04-x64/native/libhighlight-v3_60_0_0.so" />
    <file src="/home/runner/work/Smdn.LibHighlightSharp/Smdn.LibHighlightSharp/src/Smdn.LibHighlightSharp.Bindings/runtimes/ubuntu.20.04-x64/native/libhighlight-v3_60_0_0.so" target="runtimes/ubuntu.20.04-x64/native/libhighlight-v3_60_0_0.so" />
    <file src="/home/runner/work/Smdn.LibHighlightSharp/Smdn.LibHighlightSharp/src/Smdn.LibHighlightSharp.Bindings/runtimes/osx-x64/native/libhighlight-v3_60_0_0.dylib" target="runtimes/osx-x64/native/libhighlight-v3_60_0_0.dylib" />
    <file src="/home/runner/work/Smdn.LibHighlightSharp/Smdn.LibHighlightSharp/src/Smdn.LibHighlightSharp.Bindings/runtimes/win-x64/native/highlight-v3_60_0_0.dll" target="runtimes/win-x64/native/highlight-v3_60_0_0.dll" />
    <file src="/home/runner/work/Smdn.LibHighlightSharp/Smdn.LibHighlightSharp/src/Smdn.LibHighlightSharp.Bindings/runtimes/win-x64/native/lua53.dll" target="runtimes/win-x64/native/lua53.dll" />
  </files>
</package>
```

